### PR TITLE
fixed compiling with GHC 7.8.1

### DIFF
--- a/src/Distribution/Client/Dynamic/Query.hs
+++ b/src/Distribution/Client/Dynamic/Query.hs
@@ -46,7 +46,9 @@ import           System.IO.Error (isAlreadyExistsError)
 import           Text.ParserCombinators.ReadP
 
 #if __GLASGOW_HASKELL__ >= 707
+#if __GLASGOW_HASKELL__ < 708
 type Typeable1 (f :: * -> *) = Typeable f
+#endif
 #endif 
 
 -- | This is just a dummy type representing a LocalBuildInfo. You don't have to use


### PR DESCRIPTION
GHC 7.8.1 exports Typeable1 again, so this fix needs to be removed from that version on.
